### PR TITLE
feat: add jwt auth with refresh tokens

### DIFF
--- a/src/main/java/me/quadradev/application/auth/AuthController.java
+++ b/src/main/java/me/quadradev/application/auth/AuthController.java
@@ -1,0 +1,31 @@
+package me.quadradev.application.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody LoginRequest request) {
+        AuthTokens tokens = authService.login(request.email(), request.password());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.accessToken())
+                .header("Refresh-Token", tokens.refreshToken())
+                .build();
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<Void> refresh(@RequestHeader("Refresh-Token") String refreshToken) {
+        String newAccessToken = authService.refreshAccessToken(refreshToken);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken)
+                .build();
+    }
+}

--- a/src/main/java/me/quadradev/application/auth/AuthService.java
+++ b/src/main/java/me/quadradev/application/auth/AuthService.java
@@ -1,0 +1,41 @@
+package me.quadradev.application.auth;
+
+import lombok.RequiredArgsConstructor;
+import me.quadradev.application.core.model.User;
+import me.quadradev.application.core.repository.UserRepository;
+import me.quadradev.common.exception.ApiException;
+import me.quadradev.common.security.JwtProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    public AuthTokens login(String email, String password) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ApiException("Credenciales inválidas", HttpStatus.UNAUTHORIZED));
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new ApiException("Credenciales inválidas", HttpStatus.UNAUTHORIZED);
+        }
+
+        return new AuthTokens(
+                jwtProvider.generateAccessToken(email),
+                jwtProvider.generateRefreshToken(email)
+        );
+    }
+
+    public String refreshAccessToken(String refreshToken) {
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new ApiException("Refresh token inválido o expirado", HttpStatus.UNAUTHORIZED);
+        }
+        String email = jwtProvider.getEmailFromToken(refreshToken);
+        return jwtProvider.generateAccessToken(email);
+    }
+}

--- a/src/main/java/me/quadradev/application/auth/AuthTokens.java
+++ b/src/main/java/me/quadradev/application/auth/AuthTokens.java
@@ -1,0 +1,3 @@
+package me.quadradev.application.auth;
+
+public record AuthTokens(String accessToken, String refreshToken) {}

--- a/src/main/java/me/quadradev/application/auth/LoginRequest.java
+++ b/src/main/java/me/quadradev/application/auth/LoginRequest.java
@@ -1,0 +1,3 @@
+package me.quadradev.application.auth;
+
+public record LoginRequest(String email, String password) {}

--- a/src/main/java/me/quadradev/application/core/repository/UserRepository.java
+++ b/src/main/java/me/quadradev/application/core/repository/UserRepository.java
@@ -7,8 +7,10 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificationExecutor<User> {
     List<User> findByStatus(UserStatus status);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/me/quadradev/common/security/JwtFilter.java
+++ b/src/main/java/me/quadradev/common/security/JwtFilter.java
@@ -29,10 +29,10 @@ public class JwtFilter extends OncePerRequestFilter {
         String header = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring(7);
-            if (jwtProvider.validate(token)) {
-                String username = jwtProvider.getUsername(token);
+            if (jwtProvider.validateToken(token)) {
+                String email = jwtProvider.getEmailFromToken(token);
                 UsernamePasswordAuthenticationToken auth =
-                        new UsernamePasswordAuthenticationToken(username, null, List.of());
+                        new UsernamePasswordAuthenticationToken(email, null, List.of());
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
         }

--- a/src/main/java/me/quadradev/common/security/JwtProperties.java
+++ b/src/main/java/me/quadradev/common/security/JwtProperties.java
@@ -1,0 +1,16 @@
+package me.quadradev.common.security;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Setter
+public class JwtProperties {
+    private String secret;
+    private long accessTokenExpirationMs;
+    private long refreshTokenExpirationMs;
+}

--- a/src/main/java/me/quadradev/common/security/SecurityConfig.java
+++ b/src/main/java/me/quadradev/common/security/SecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
 
@@ -29,6 +31,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/users/**").permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
@@ -43,5 +46,10 @@ public class SecurityConfig {
             config.setAllowedHeaders(List.of("*"));
             return config;
         };
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,5 +9,6 @@ spring.jpa.show-sql=true
 springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 
-jwt.secret=ChangeMeSecretKeyChangeMeSecretKey
-jwt.expiration=3600000
+jwt.secret=Cl4veJWTsupersecreta!
+jwt.access-token-expiration-ms=900000
+jwt.refresh-token-expiration-ms=604800000


### PR DESCRIPTION
## Summary
- add configuration-driven JWT token generation and refresh logic
- expose `/api/auth` endpoints for login and token refresh
- secure API with JWT filter and password encoder

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894050379e88330a1c0172ea83a9aea