### PR TITLE
Improve auth validation and security config

### DIFF
--- a/src/main/java/me/quadradev/application/auth/AuthController.java
+++ b/src/main/java/me/quadradev/application/auth/AuthController.java
@@ -1,5 +1,6 @@
 package me.quadradev.application.auth;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,7 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<Void> login(@RequestBody @Valid LoginRequest request) {
         AuthTokens tokens = authService.login(request.email(), request.password());
         return ResponseEntity.ok()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.accessToken())

--- a/src/main/java/me/quadradev/application/auth/AuthService.java
+++ b/src/main/java/me/quadradev/application/auth/AuthService.java
@@ -1,5 +1,7 @@
 package me.quadradev.application.auth;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import me.quadradev.application.core.model.User;
 import me.quadradev.application.core.repository.UserRepository;
@@ -32,10 +34,13 @@ public class AuthService {
     }
 
     public String refreshAccessToken(String refreshToken) {
-        if (!jwtProvider.validateToken(refreshToken)) {
-            throw new ApiException("Refresh token inválido o expirado", HttpStatus.UNAUTHORIZED);
+        try {
+            String email = jwtProvider.getEmailFromToken(refreshToken);
+            return jwtProvider.generateAccessToken(email);
+        } catch (ExpiredJwtException e) {
+            throw new ApiException("Refresh token expirado", HttpStatus.UNAUTHORIZED);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new ApiException("Refresh token inválido", HttpStatus.UNAUTHORIZED);
         }
-        String email = jwtProvider.getEmailFromToken(refreshToken);
-        return jwtProvider.generateAccessToken(email);
     }
 }

--- a/src/main/java/me/quadradev/application/auth/LoginRequest.java
+++ b/src/main/java/me/quadradev/application/auth/LoginRequest.java
@@ -1,3 +1,9 @@
 package me.quadradev.application.auth;
 
-public record LoginRequest(String email, String password) {}
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank @Email String email,
+        @NotBlank String password
+) {}

--- a/src/main/java/me/quadradev/common/security/JwtProvider.java
+++ b/src/main/java/me/quadradev/common/security/JwtProvider.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 
@@ -17,7 +18,7 @@ public class JwtProvider {
     private final JwtProperties jwtProperties;
 
     private Key getSigningKey() {
-        return Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes());
+        return Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
     }
 
     public String generateToken(String subject, long expirationMs) {

--- a/src/main/java/me/quadradev/common/security/SecurityConfig.java
+++ b/src/main/java/me/quadradev/common/security/SecurityConfig.java
@@ -6,12 +6,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
 
@@ -19,6 +19,13 @@ import java.util.List;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private static final String[] PUBLIC_ENDPOINTS = {
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/api/auth/**",
+            "/api/users/**"
+    };
 
     private final JwtFilter jwtFilter;
 
@@ -29,9 +36,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/api/users/**").permitAll()
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();


### PR DESCRIPTION
## Summary
- add bean validation for login requests
- encode JWT secret using UTF-8 and refine refresh token error handling
- simplify security config with public endpoint constant

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68940a0fa3d48330ad53b6480f6a09e4