### PR TITLE
Encode user passwords before saving

### DIFF
--- a/src/main/java/me/quadradev/application/core/service/UserService.java
+++ b/src/main/java/me/quadradev/application/core/service/UserService.java
@@ -6,6 +6,7 @@ import me.quadradev.application.core.model.UserStatus;
 import me.quadradev.application.core.repository.UserRepository;
 import me.quadradev.application.core.specification.UserSpecifications;
 import me.quadradev.common.exception.ApiException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.data.jpa.domain.Specification;
@@ -18,6 +19,7 @@ import java.util.Optional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public List<User> findAll() {
         return userRepository.findAll();
@@ -28,6 +30,7 @@ public class UserService {
     }
 
     public User createUser(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
         return userRepository.save(user);
     }
 

--- a/src/test/java/me/quadradev/application/core/service/UserServiceTest.java
+++ b/src/test/java/me/quadradev/application/core/service/UserServiceTest.java
@@ -1,0 +1,48 @@
+package me.quadradev.application.core.service;
+
+import me.quadradev.application.core.model.User;
+import me.quadradev.application.core.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void createUserShouldEncodePasswordBeforeSaving() {
+        User user = User.builder()
+                .password("plainPassword")
+                .build();
+        String encodedPassword = "encodedPassword";
+
+        when(passwordEncoder.encode("plainPassword")).thenReturn(encodedPassword);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User result = userService.createUser(user);
+
+        assertEquals(encodedPassword, result.getPassword());
+        assertNotEquals("plainPassword", result.getPassword());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertEquals(encodedPassword, userCaptor.getValue().getPassword());
+    }
+}


### PR DESCRIPTION
## Summary
- inject `PasswordEncoder` into `UserService` to encode passwords before saving
- add unit test ensuring passwords are not persisted in plain text

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM; could not transfer artifact from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_6894cea097548330becb5f1daa0beab8