### PR TITLE
Validate user status during login

### DIFF
--- a/src/main/java/me/quadradev/application/auth/AuthService.java
+++ b/src/main/java/me/quadradev/application/auth/AuthService.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import me.quadradev.application.core.model.User;
+import me.quadradev.application.core.model.UserStatus;
 import me.quadradev.application.core.repository.UserRepository;
 import me.quadradev.common.exception.ApiException;
 import me.quadradev.common.security.JwtProvider;
@@ -22,6 +23,10 @@ public class AuthService {
     public AuthTokens login(String email, String password) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new ApiException("Credenciales inválidas", HttpStatus.UNAUTHORIZED));
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new ApiException("Usuario inactivo", HttpStatus.FORBIDDEN);
+        }
 
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new ApiException("Credenciales inválidas", HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
## Summary
- prevent inactive users from logging in by checking `UserStatus`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.2 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894fa2fcd008330b559dbc7012765fb