### PR TITLE
Enforce unique email in user entity

### DIFF
--- a/src/main/java/me/quadradev/application/core/model/User.java
+++ b/src/main/java/me/quadradev/application/core/model/User.java
@@ -23,6 +23,7 @@ public class User {
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
 
+    @Column(unique = true)
     private String email;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/src/main/java/me/quadradev/application/core/service/UserService.java
+++ b/src/main/java/me/quadradev/application/core/service/UserService.java
@@ -30,6 +30,9 @@ public class UserService {
     }
 
     public User createUser(User user) {
+        if (userRepository.findByEmail(user.getEmail()).isPresent()) {
+            throw new ApiException("Email already exists", HttpStatus.CONFLICT);
+        }
         user.setPassword(passwordEncoder.encode(user.getPassword()));
         return userRepository.save(user);
     }


### PR DESCRIPTION
## Summary
- mark user email as unique in database
- reject user creation when email already exists

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894fb50401483309ac5c4caab0fd8fb