### PR TITLE
Enable Spring Data JPA auditing for user timestamps

### DIFF
--- a/src/main/java/me/quadradev/application/core/model/User.java
+++ b/src/main/java/me/quadradev/application/core/model/User.java
@@ -1,15 +1,17 @@
 package me.quadradev.application.core.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "users")
-@EntityListeners(User.AuditListener.class)
+@EntityListeners(AuditingEntityListener.class)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -34,23 +36,11 @@ public class User {
     @Column(nullable = false)
     private UserStatus status = UserStatus.ACTIVE;
 
+    @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
-
-    @PrePersist
-    public void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    @PreUpdate
-    public void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    public static class AuditListener {
-    }
 }

--- a/src/main/java/me/quadradev/config/DatabaseConfig.java
+++ b/src/main/java/me/quadradev/config/DatabaseConfig.java
@@ -3,11 +3,13 @@ package me.quadradev.config;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @EnableTransactionManagement
 @EnableJpaRepositories(basePackages = "me.quadradev.application.core.repository")
 @EntityScan(basePackages = "me.quadradev.application.core.model")
+@EnableJpaAuditing
 public class DatabaseConfig {
 }


### PR DESCRIPTION
## Summary
- replace manual timestamp handling with Spring Data auditing on `User`
- annotate created and updated timestamps with `@CreatedDate` and `@LastModifiedDate`
- enable JPA auditing in `DatabaseConfig`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_6894fd3a6f888330bef93463197ed73b